### PR TITLE
Fix compiler warnings: use non-deprecated constants

### DIFF
--- a/YACYAML.xcodeproj/project.pbxproj
+++ b/YACYAML.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 				WARNING_CFLAGS = "-Wall";
 			};
@@ -743,7 +743,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 				WARNING_CFLAGS = "-Wall";

--- a/YACYAML.xcodeproj/project.pbxproj
+++ b/YACYAML.xcodeproj/project.pbxproj
@@ -530,7 +530,7 @@
 			name = YACYAMLTests;
 			productName = YACYAMLTests;
 			productReference = 7DDC031E156541F8001832F5 /* YACYAMLTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 		7DE3E3AB15654430006663D2 /* libYAML */ = {
 			isa = PBXNativeTarget;
@@ -708,7 +708,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = macosx10.10;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 				WARNING_CFLAGS = "-Wall";
 			};
@@ -743,7 +743,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
-				SDKROOT = iphoneos;
+				SDKROOT = macosx10.10;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 				WARNING_CFLAGS = "-Wall";

--- a/YACYAML/Archiving/YACYAMLArchivingExtensions.m
+++ b/YACYAML/Archiving/YACYAMLArchivingExtensions.m
@@ -189,15 +189,15 @@
 {
     NSString *ret = nil;
     
-    NSUInteger units =  NSYearCalendarUnit | 
-                        NSMonthCalendarUnit |  
-                        NSDayCalendarUnit | 
-                        NSHourCalendarUnit | 
-                        NSMinuteCalendarUnit | 
-                        NSSecondCalendarUnit |
-                        NSTimeZoneCalendarUnit;
+    NSUInteger units =  NSCalendarUnitYear |
+                        NSCalendarUnitMonth |
+                        NSCalendarUnitDay |
+                        NSCalendarUnitHour |
+                        NSCalendarUnitMinute |
+                        NSCalendarUnitSecond |
+                        NSCalendarUnitTimeZone;
     
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
      
     NSDateComponents *components = [calendar components:units fromDate:self];

--- a/YACYAML/Archiving/YACYAMLKeyedArchiver.m
+++ b/YACYAML/Archiving/YACYAMLKeyedArchiver.m
@@ -400,12 +400,12 @@ static int EmitToNSMutableData(void *ext, unsigned char *buffer, size_t size)
             [NSException raise:YACYAMLUnsupportedTypeException format:@"Tried to encode value of unhandled type"];
 	}
     
-    [self encodeObject:toEncode forKey:nil];
+    [self encodeObject:toEncode forKey:NSStringFromClass(self.class)];
 }
 
 - (void)encodeDataObject:(NSData *)data
 {
-    [self encodeObject:data forKey:nil];
+    [self encodeObject:data forKey:NSStringFromClass(self.class)];
 }
 
 @end

--- a/YACYAML/Unarchiving/YACYAMLUnarchivingExtensions.m
+++ b/YACYAML/Unarchiving/YACYAMLUnarchivingExtensions.m
@@ -474,7 +474,7 @@ static NSRegularExpression *YACYAMLTimestampComplicatedRegularExpression(void)
         dateComponents.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:secondsFromGMT];
     }
     
-    NSCalendar *calender = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *calender = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     calender.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     
     NSDate *ret = [calender dateFromComponents:dateComponents];


### PR DESCRIPTION
Formally deprecated in OS X 10.10 and iOS 8:
- `NSYearCalendarUnit` & friends in favor of `NSCalendarUnitYear` etc.
- dto for `NSGregorianCalendar` in favor of `NSCalendarIdentifierGregorian`.
